### PR TITLE
docs: replace CRA template README with project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,35 @@
-# Getting Started with Create React App
+# AmbAnime
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+An anime browsing web app built with **React (Create React App)** + **Firebase**.
 
-## Available Scripts
+Data is fetched from the **Jikan API** (MyAnimeList unofficial API): https://api.jikan.moe/v4 (see `src/services/api.js`).
 
-In the project directory, you can run:
+## Features
+- Browse & search anime
+- Anime detail pages (characters, recommendations)
+- User authentication (Firebase Auth)
+- User data in Firestore (favorites, watchlist)
+- Reviews stored in Firestore
+- Basic admin utilities (e.g. list users / delete user data)
 
-### `npm start`
+## Tech stack
+- React (CRA)
+- Firebase (Auth + Firestore)
+- React Router
+- Framer Motion
+- Recharts
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+## Run locally
+```bash
+npm install
+npm start
+```
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+## Notes
+- The Jikan API is rate-limited; this project includes simple retry/backoff handling.
+- Firebase config is currently in `src/services/firebase.js`.
 
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+## Portfolio notes
+- Integrating a public API + handling rate limits
+- Full auth + user state with Firebase
+- CRUD features (favorites/watchlist/reviews)


### PR DESCRIPTION
Replaces the Create React App template README with a project/portfolio README.
Includes:
- features
- stack
- local run
- data source (Jikan API) + rate-limit note

No secrets added.